### PR TITLE
front: allow free HTML form in talk track

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+!frontend/app/lib/

--- a/frontend/app/page.jsx
+++ b/frontend/app/page.jsx
@@ -18,6 +18,7 @@ import {
 import Code from "@leafygreen-ui/code";
 import InfoWizard from "@/components/InfoWizard/InfoWizard";
 import TextInput from "@leafygreen-ui/text-input";
+import { agenticPageTalkTrack } from "@/lib/talkTrack";
 
 export default function HomePage() {
   const [selectedOption, setSelectedOption] = useState("new"); // "new", "resume", or "list"
@@ -118,67 +119,7 @@ export default function HomePage() {
             setOpen={setOpenHelpModal}
             tooltipText="Tell me more!"
             iconGlyph="Wizard"
-            sections={[
-              {
-                heading: "Instructions and Talk Track",
-                content: [
-                  {
-                    heading: "Solution Overview",
-                    body: "The Agentic Framework serves as a versatile AI-driven recommendation assistant capable of comprehending your data, performing a multi-step diagnostic workflow using LangGraph, and generating actionable recommendations. The framework integrates several key technologies. It reads timeseries data from a CSV file or MongoDB (simulating various data inputs), generates text embeddings using the Cohere English V3 model, performs vector searches to identify similar past queries from MongoDB, persists session and run data, and finally generates a diagnostic recommendation. MongoDB stores agent profiles, historical recommendations, timeseries data, session logs, and more. This persistent storage not only logs every step of the diagnostic process for traceability but also enables efficient querying and reusability of past data.",
-                  },
-                  {
-                    heading: "How to Demo",
-                    body: [
-                      "Choose “New Diagnosis.",
-                      "Enter a query in the text box (e.g., the sample complaint about a knocking sound).",
-                      "Click the “Run Agent” button and wait for a few minutes as the agent finishes its run.",
-                      "The workflow, chain-of-thought output, and the final recommendation are shown in the left column.",
-                      "In the right column, the documents shown are the records inserted during the current agent run.",
-                    ],
-                  },
-                ],
-              },
-              {
-                heading: "Behind the Scenes",
-                content: [
-                  {
-                    heading: "Logical Architecture",
-                    body: "",
-                  },
-                  {
-                    image: {
-                      src: "./info.png",
-                      alt: "Logical Architecture",
-                    },
-                  },
-                ],
-              },
-              {
-                heading: "Why MongoDB?",
-                content: [
-                  {
-                    heading: "Flexible Data Model",
-                    body: "MongoDB’s document-oriented architecture allows you to store varied data (such as timeseries logs, agent profiles, and recommendation outputs) in a single unified format. This flexibility means you don’t have to redesign your database schema every time your data requirements evolve.",
-                  },
-                  {
-                    heading: "Scalability and Performance",
-                    body: "MongoDB is designed to scale horizontally, making it capable of handling large volumes of real-time data. This is essential when multiple data sources send timeseries data simultaneously, ensuring high performance under heavy load.",
-                  },
-                  {
-                    heading: "Real-Time Analytics",
-                    body: "With powerful aggregation frameworks and change streams, MongoDB supports real-time data analysis and anomaly detection. This enables the system to process incoming timeseries data on the fly and quickly surface critical insights.",
-                  },
-                  {
-                    heading: "Seamless Integration",
-                    body: "MongoDB is seamlessly integrated with LangGraph, making it a powerful memory provider.",
-                  },
-                  {
-                    heading: "Vector Search",
-                    body: "MongoDB Atlas supports native vector search, enabling fast and efficient similarity searches on embedding vectors. This is critical for matching current queries with historical data, thereby enhancing diagnostic accuracy and providing more relevant recommendations.",
-                  },
-                ],
-              },
-            ]}
+            sections={agenticPageTalkTrack}
           />
         </div>
       </div>

--- a/frontend/components/InfoWizard/InfoWizard.module.css
+++ b/frontend/components/InfoWizard/InfoWizard.module.css
@@ -34,6 +34,30 @@
   border-radius: 8px;
 }
 
+.htmlRender{
+    margin: unset;
+    font-family: 'Euclid Circular A', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    color: #001E2B;
+    font-size: 13px;
+    line-height: 20px;
+    color: #001E2B;
+    font-weight: 400;
+}
+
+.htmlRender a{
+    color: green;
+    text-decoration: underline;
+}
+
+.htmlRender a:hover{
+    color: #00a35c;
+}
+
+.htmlRender mark {
+  background-color: rgb(216, 214, 214);
+  color: black;
+}
+
 @media (max-width: 768px) {
   .modal {
     width: 95vw;

--- a/frontend/lib/talkTrack.js
+++ b/frontend/lib/talkTrack.js
@@ -1,0 +1,66 @@
+export const agenticPageTalkTrack = [
+    {
+        heading: "Instructions and Talk Track",
+        content: [
+            {
+                heading: "Solution Overview",
+                body: "The Agentic Framework serves as a versatile AI-driven recommendation assistant capable of comprehending your data, performing a multi-step diagnostic workflow using LangGraph, and generating actionable recommendations. The framework integrates several key technologies. It reads timeseries data from a CSV file or MongoDB (simulating various data inputs), generates text embeddings using the Cohere English V3 model, performs vector searches to identify similar past queries from MongoDB, persists session and run data, and finally generates a diagnostic recommendation. MongoDB stores agent profiles, historical recommendations, timeseries data, session logs, and more. This persistent storage not only logs every step of the diagnostic process for traceability but also enables efficient querying and reusability of past data.",
+            },
+            {
+                heading: "How to Demo",
+                body: [
+                    "Choose “New Diagnosis.",
+                    "Enter a query in the text box (e.g., the sample complaint about a knocking sound).",
+                    "Click the “Run Agent” button and wait for a few minutes as the agent finishes its run.",
+                    "The workflow, chain-of-thought output, and the final recommendation are shown in the left column.",
+                    "In the right column, the documents shown are the records inserted during the current agent run.",
+                ],
+            },
+        ],
+    },
+    {
+        heading: "Behind the Scenes",
+        content: [
+            {
+                heading: "Logical Architecture",
+                body: "",
+            },
+            {
+                image: {
+                    src: "./info.png",
+                    alt: "Logical Architecture",
+                },
+            },
+        ],
+    },
+    {
+        heading: "Why MongoDB?",
+        content: [
+            {
+                heading: "Flexible Data Model",
+                body: `<div>MongoDB's <a href="https://www.mongodb.com/resources/basics/databases/document-databases" target="_blank">document-oriented architecture</a> allows you to store varied data 
+                (such as <i>timeseries logs, agent profiles, and recommendation outputs</i>) 
+                in a <strong>single unified format</strong>. This flexibility means you don’t have to redesign your database <mark>schema</mark> every time your data requirements evolve.</div>`,
+                isHTML:true
+            },
+            {
+                heading: "Scalability and Performance",
+                body: "MongoDB is designed to scale horizontally, making it capable of handling large volumes of real-time data. This is essential when multiple data sources send timeseries data simultaneously, ensuring high performance under heavy load.",
+            },
+            {
+                heading: "Real-Time Analytics",
+                body: "With powerful aggregation frameworks and change streams, MongoDB supports real-time data analysis and anomaly detection. This enables the system to process incoming timeseries data on the fly and quickly surface critical insights.",
+            },
+            {
+                heading: "Seamless Integration",
+                body: "MongoDB is seamlessly integrated with LangGraph, making it a powerful memory provider.",
+            },
+            {
+                heading: "Vector Search",
+                body: "MongoDB Atlas supports native vector search, enabling fast and efficient similarity searches on embedding vectors. This is critical for matching current queries with historical data, thereby enhancing diagnostic accuracy and providing more relevant recommendations.",
+            },
+        ],
+    },
+]
+
+// Add bellow the talk tracks for other sections/pages


### PR DESCRIPTION
Changes include
- Add a /lib/talkTrack.js file to store all the talk track sections. (improves readability and maintenance)
- Allow freeHTML format inside talk track sections. This targets current limitation to freely style text like: Having bold text, italic, mark, inline styles, icons in the middle of a sentences, etc...
- updated. TalkTrack component to receive isHTML parameter