### PR TITLE
Fix: default dark mode styling

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2,13 +2,13 @@
   --background: #ffffff;
   --foreground: #171717;
 }
-
-@media (prefers-color-scheme: dark) {
+/* Uncomment this line to implement default dark mode colors if system is set to dark mode */
+/* @media (prefers-color-scheme: dark) {
   :root {
     --background: #ffffff;
     --foreground: #ededed;
   }
-}
+} */
 
 html,
 body {


### PR DESCRIPTION
the dark mode version of the template was active by default if the computer settings are set to dark mode, this default setting was making any text to be almost unreadable unless otherwise specified in another css file, this fix comments the problematic css code that by default implemented this option.

Before:
<img width="408" alt="Screenshot 2025-07-01 at 12 18 27 PM" src="https://github.com/user-attachments/assets/e6712547-5610-42f3-be10-da9ee3b767fd" />

After:
<img width="288" alt="Screenshot 2025-07-01 at 12 26 31 PM" src="https://github.com/user-attachments/assets/4400a74c-86de-40dd-bf0a-4df8e114107e" />
